### PR TITLE
Update events.lua - Fix multiplayer error: 

### DIFF
--- a/mod/COLOSSUS/factorio/events.lua
+++ b/mod/COLOSSUS/factorio/events.lua
@@ -455,10 +455,10 @@ function Toggle_interface(player, keep_elements)
         player_global.elements = {}
     end
     if player_global.surface == nil then
-        player_global.surface = game.create_surface("colussus_mod_colossus")
+        player_global.surface = game.create_surface("colussus_mod_colossus_" .. player.index)
     end
     if player_global.blueprint_surface == nil then
-        player_global.blueprint_surface = game.create_surface("colussus_mod_colossus_blueprint_surface")
+        player_global.blueprint_surface = game.create_surface("colussus_mod_colossus_blueprint_surface_" .. player.index)
         player_global.blueprint_surface.generate_with_lab_tiles = true
         player_global.blueprint_surface.always_day = true
     end


### PR DESCRIPTION
"Surface names must not be blank and must be unique"

create_surface throws an exception if the given value is blank or not unique, this is the case on multiplayer where every player after the first tries to close the UI which causes the exception to be thrown.

This fix is tested and confirmed working in multiplayer with 2 players.